### PR TITLE
Update the `recommended` config to also disable the `no-unnecessary-concat` stylistic rule

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -5,6 +5,7 @@ module.exports = {
   // ember-template-lint stylistic rules
   "block-indentation": false,
   "linebreak-style": false,
+  "no-unnecessary-concat": false,
   quotes: false,
   "self-closing-void-elements": false
 };


### PR DESCRIPTION
`no-unnecessary-concat` is one of the stylistic rules that is removed from ember-template-lint's `recommended` config in v2: https://github.com/ember-template-lint/ember-template-lint/pull/899