### PR TITLE
if unable to resolve a config from filepath, try cwd

### DIFF
--- a/lib/rules/prettier.js
+++ b/lib/rules/prettier.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const path = require("path");
+
 const {
   showInvisibles,
   generateDifferences
@@ -45,9 +47,20 @@ module.exports = class Prettier extends Rule {
             prettier = require("prettier");
           }
 
-          const prettierRcOptions = prettier.resolveConfig.sync(filepath, {
+          let prettierRcOptions = prettier.resolveConfig.sync(filepath, {
             editorconfig: true
           });
+
+          if (!prettierRcOptions) {
+            // If unable to resolve a config from filepath, try cwd.
+            prettierRcOptions = prettier.resolveConfig.sync(
+              // Append file name to pick up overrides.
+              process.cwd() + "/" + path.basename(filepath),
+              {
+                editorconfig: true
+              }
+            );
+          }
 
           const prettierFileInfo = prettier.getFileInfo.sync(filepath, {
             ignorePath: ".prettierignore"


### PR DESCRIPTION
When used with editor tools that write out to a temp file outside the project (e.g. ALE), the prettier config file cannot be found. This adds a fallback to look in cwd for a prettier config if one is not found. It appends the file basename to cwd to try to pick up any overrides (e.g. for `*.hbs`).