### PR TITLE
CI: Fix floating dependencies job

### DIFF
--- a/test/unit/rules/lint-prettier-test.js
+++ b/test/unit/rules/lint-prettier-test.js
@@ -4,7 +4,7 @@ const plugin = require("../../../ember-template-lint-plugin-prettier");
 generateRuleTests({
   name: "prettier",
 
-  groupMethodBefore: beforeEach,
+  groupMethodBefore: before,
   groupingMethod: describe,
   testMethod: it,
   plugins: [plugin],


### PR DESCRIPTION
A bug surfaced in ember-template-lint test harness. While waiting for a proper fix there, this change will fix the CI.