### PR TITLE
Fix typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ to your `.template-lintrc.js` file:
 module.exports = {
   plugins: ["ember-template-lint-plugin-prettier"],
 
-  extends: ["recommended", "ember-template-lint-plugin-prettier:recommended"],
-  },
+  extends: ["recommended", "ember-template-lint-plugin-prettier:recommended"]
 };
 ```
 


### PR DESCRIPTION
Removes an errant closing bracket from a code sample.