### PR TITLE
Fix tests setup

### DIFF
--- a/test/unit/rules/lint-prettier-test.js
+++ b/test/unit/rules/lint-prettier-test.js
@@ -4,7 +4,7 @@ const plugin = require("../../../ember-template-lint-plugin-prettier");
 generateRuleTests({
   name: "prettier",
 
-  groupMethodBefore: before,
+  groupMethodBefore: beforeEach,
   groupingMethod: describe,
   testMethod: it,
   plugins: [plugin],


### PR DESCRIPTION
This change will allow the config to be reset before each test.

It fixes the error thrown by ember-template-lint and will fix the floating dependencies tests.