### PR TITLE
Ensuring we pass node and/or line, column, endLine, endColumn to log

### DIFF
--- a/lib/rules/prettier.js
+++ b/lib/rules/prettier.js
@@ -90,8 +90,12 @@ module.exports = class Prettier extends Rule {
 
             this.log({
               message,
+              // As of ember-template-lint@3.8.0, passing line and column whose values match the
+              // reference node's line and column isn't required (it uses the node's line/column).
+              // In order to support older versions (> 3.8.0), we're keeping these properties here.
               line: node.loc && node.loc.start.line,
               column: node.loc && node.loc.start.column,
+              node,
               source,
             });
 
@@ -131,7 +135,15 @@ module.exports = class Prettier extends Rule {
                   break;
               }
 
-              this.log({ message, line, column, source, isFixable: true });
+              this.log({
+                message,
+                line,
+                column,
+                endLine: line,
+                endColumn: column,
+                source,
+                isFixable: true,
+              });
             });
           }
         },

--- a/lib/rules/prettier.js
+++ b/lib/rules/prettier.js
@@ -112,8 +112,12 @@ module.exports = class Prettier extends Rule {
 
             differences.forEach((difference) => {
               let message = "";
-              let { line, column } = getLocFromIndex(
-                difference.offset,
+              // `difference.offset` is the offset from the beginning
+              // of the template, ie. it is the index
+              let { offset, deleteText = "" } = difference;
+              let { line, column } = getLocFromIndex(offset, this.source);
+              let { line: endLine, column: endColumn } = getLocFromIndex(
+                offset + deleteText.length,
                 this.source
               );
 
@@ -139,8 +143,8 @@ module.exports = class Prettier extends Rule {
                 message,
                 line,
                 column,
-                endLine: line,
-                endColumn: column,
+                endLine,
+                endColumn,
                 source,
                 isFixable: true,
               });

--- a/test/unit/rules/lint-prettier-test.js
+++ b/test/unit/rules/lint-prettier-test.js
@@ -35,7 +35,7 @@ test
         line: 1,
         column: 34,
         endLine: 1,
-        endColumn: 34,
+        endColumn: 35,
         source: "{{#my-component}}{{/my-component}}\n",
         isFixable: true,
       },
@@ -52,8 +52,8 @@ test
         message: 'Replace `⏎·data-bar="lol"⏎·····` with ` data-bar="lol"`',
         line: 1,
         column: 13,
-        endLine: 1,
-        endColumn: 13,
+        endLine: 3,
+        endColumn: 5,
         source: `<div data-foo
  data-bar="lol"
       some-other-thing={{haha-morethaneightychars}}>
@@ -70,7 +70,7 @@ test
         line: 1,
         column: 4,
         endLine: 1,
-        endColumn: 4,
+        endColumn: 5,
         source: "test\n",
         isFixable: true,
       },
@@ -112,7 +112,7 @@ test
         line: 2,
         column: 6,
         endLine: 2,
-        endColumn: 6,
+        endColumn: 7,
         source:
           '{{#my-component class="class1 class2"}}\n  test \n\n{{/my-component}}',
         isFixable: true,

--- a/test/unit/rules/lint-prettier-test.js
+++ b/test/unit/rules/lint-prettier-test.js
@@ -34,6 +34,8 @@ test
         message: "Delete `⏎`",
         line: 1,
         column: 34,
+        endLine: 1,
+        endColumn: 34,
         source: "{{#my-component}}{{/my-component}}\n",
         isFixable: true,
       },
@@ -50,6 +52,8 @@ test
         message: 'Replace `⏎·data-bar="lol"⏎·····` with ` data-bar="lol"`',
         line: 1,
         column: 13,
+        endLine: 1,
+        endColumn: 13,
         source: `<div data-foo
  data-bar="lol"
       some-other-thing={{haha-morethaneightychars}}>
@@ -65,6 +69,8 @@ test
         message: "Delete `⏎`",
         line: 1,
         column: 4,
+        endLine: 1,
+        endColumn: 4,
         source: "test\n",
         isFixable: true,
       },
@@ -85,6 +91,8 @@ test
         message: "Insert `··`",
         line: 2,
         column: 1,
+        endLine: 2,
+        endColumn: 1,
         source: "{{#my-component}}\n\ntest\n\n{{/my-component}}",
         isFixable: true,
       },
@@ -103,6 +111,8 @@ test
         message: "Delete `·`",
         line: 2,
         column: 6,
+        endLine: 2,
+        endColumn: 6,
         source:
           '{{#my-component class="class1 class2"}}\n  test \n\n{{/my-component}}',
         isFixable: true,


### PR DESCRIPTION
Fixes #175. 

We should determine whether it's adequate to pass `line`/`column` as `endLine`/`endColumn` for the differences, as it's not clear to me if higher fidelity `endLine`/`endColumn` is necessary here.

This change should be backwards compatible with older versions, since passing node and/or `endLine`/`endColumn` should be considered "safe", even in older versions.