### PR TITLE
Require ember-template-lint v4 beta as a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ error: Replace `New·Addons</h1>` with <h1>⏎New Addons⏎</h1>` (prettier/pret
 
 > `./node_modules/.bin/ember-template-lint app/templates/lists/new-addons.hbs` (code from [emberobserver](https://github.com/emberobserver/client)).
 
+## Compatibility
+
+- [Node.js](https://nodejs.org/) `^12.22.0 || ^14.17.0 || >=16.0.0`
+- [ember-template-lint](https://github.com/ember-template-lint/ember-template-lint/) `^4.0.0-beta.3`
+- [prettier](https://prettier.io/) `>=1.18.1`
+
 ## Install
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release-it-lerna-changelog": "^4.0.1"
   },
   "peerDependencies": {
-    "ember-template-lint": ">=2.10.0",
+    "ember-template-lint": "^4.0.0-beta.3",
     "prettier": ">=1.18.1"
   },
   "engines": {


### PR DESCRIPTION
As it will allow us to release a v4 beta for ember-template-lint-plugin-prettier. 

The plan in future PRs is to:
- require ember-template-lint v4 (when it is released)
- restrict the peerDependency support to ">=2.10.0 || 3" for ember-template-lint-plugin-prettier@3